### PR TITLE
Fix up build

### DIFF
--- a/.metadata.sh
+++ b/.metadata.sh
@@ -38,7 +38,10 @@ ITERATION=$(git rev-list --count --all || echo 0)
 DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 COMMIT="$(git rev-parse --short HEAD || echo 0)"
 
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD || echo unknown)"
+BRANCH="${TRAVIS_BRANCH:-${GIT_BRANCH}}"
+
 # This is a custom download path for homebrew formula.
 SOURCE_PATH=https://golift.io/${BINARY}/archive/v${VERSION}.tar.gz
 
-export SOURCE_URL URL VVERSION VERSION ITERATION DATE COMMIT SOURCE_PATH
+export SOURCE_URL URL VVERSION VERSION ITERATION DATE BRANCH COMMIT SOURCE_PATH

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ endef
 PLUGINS:=$(patsubst plugins/%/main.go,%,$(wildcard plugins/*/main.go))
 
 VERSION_LDFLAGS:= \
-  -X github.com/prometheus/common/version.Branch=$(TRAVIS_BRANCH) \
+  -X github.com/prometheus/common/version.Branch=$(BRANCH) \
   -X github.com/prometheus/common/version.BuildDate=$(DATE) \
   -X github.com/prometheus/common/version.Revision=$(COMMIT) \
   -X github.com/prometheus/common/version.Version=$(VERSION)-$(ITERATION)
@@ -285,7 +285,7 @@ lint:
 # This is safe; recommended even.
 dep: vendor
 vendor: go.mod go.sum
-	go mod vendor
+	go mod download
 
 # Don't run this unless you're ready to debug untested vendored dependencies.
 deps: update vendor

--- a/init/docker/Dockerfile
+++ b/init/docker/Dockerfile
@@ -19,8 +19,7 @@ RUN mkdir -p $GOPATH/pkg/mod $GOPATH/bin $GOPATH/src /${BINARY}
 COPY . /${BINARY}
 WORKDIR /${BINARY}
 
-RUN go mod vendor \
-  && CGO_ENABLED=0 make ${BINARY}.${ARCH}.${OS}
+RUN CGO_ENABLED=0 make ${BINARY}.${ARCH}.${OS}
 
 FROM scratch
 ARG ARCH


### PR DESCRIPTION
* Use `go mod download` for "vendor", as the `vendor/` dir is ignored by
the build anyway.
* Fix branch info embedding when not running in Travis.

Signed-off-by: Ben Kochie <superq@gmail.com>