### PR TITLE
Improve arch detection, add "aarch64" as arm64 platform

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,8 @@ elif [[ $ARCH == *386* ]] || [[ $ARCH == *686* ]]; then
   ARCH="i386"
 elif [[ $ARCH == *arm64* ]] || [[ $ARCH == *armv8* ]]; then
   ARCH="arm64"
+elif [[ $ARCH == *aarch64* ]] || [[ $ARCH == *armv8* ]]; then
+  ARCH="arm64"
 elif [[ $ARCH == *armv6* ]] || [[ $ARCH == *armv7* ]]; then
   ARCH="armhf"
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,9 +20,7 @@ if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
   ARCH="x86_64|amd64"
 elif [[ $ARCH == *386* ]] || [[ $ARCH == *686* ]]; then
   ARCH="i386"
-elif [[ $ARCH == *arm64* ]] || [[ $ARCH == *armv8* ]]; then
-  ARCH="arm64"
-elif [[ $ARCH == *aarch64* ]] || [[ $ARCH == *armv8* ]]; then
+elif [[ $ARCH == *arm64* ]] || [[ $ARCH == *armv8* ]] || [[ $ARCH == *aarch64* ]]; then
   ARCH="arm64"
 elif [[ $ARCH == *armv6* ]] || [[ $ARCH == *armv7* ]]; then
   ARCH="armhf"


### PR DESCRIPTION
On a Debian Stretch running on "aarch64" aka arm64 the install script does not recognize as a valid platform. This little change fixes this.