### PR TITLE
Fixes #191 - update env vars, *actually* enable auth

### DIFF
--- a/init/docker/docker-compose.env.example
+++ b/init/docker/docker-compose.env.example
@@ -1,10 +1,14 @@
-INFLUXDB_USER=admin
-INFLUXDB_PASS=influxadmin
+#influxdb
+INFLUXDB_HTTP_AUTH_ENABLED=true
+INFLUXDB_ADMIN_USER=unifi-poller
+INFLUXDB_ADMIN_PASSWORD=CHANGEME
 INFLUXDB_DB=unifi
 
+#grafana
 GRAFANA_USERNAME=admin
 GRAFANA_PASSWORD=grafanaadmin
 
+#unifi-poller
 # 2 means latest v2 release.
 POLLER_TAG=2
 POLLER_DEBUG=false

--- a/init/docker/docker-compose.yml
+++ b/init/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 # This is for unifi-poller v2.
-version: '2'
+version: '3'
 services:
   influxdb:
     restart: always
@@ -10,8 +10,9 @@ services:
       - influxdb-storage:/var/lib/influxdb
     environment:
       - INFLUXDB_DB=${INFLUXDB_DB}
-      - INFLUXDB_ADMIN_USER=${INFLUXDB_USER}
-      - INFLUXDB_ADMIN_PASSWORD=${INFLUXDB_PASS}
+      - INFLUXDB_HTTP_AUTH_ENABLED=${INFLUXDB_HTTP_AUTH_ENABLED}
+      - INFLUXDB_ADMIN_USER=${INFLUXDB_ADMIN_USER}
+      - INFLUXDB_ADMIN_PASSWORD=${INFLUXDB_ADMIN_PASSWORD}
   chronograf:
     image: chronograf:latest
     restart: always
@@ -23,8 +24,8 @@ services:
       - influxdb
     environment:
       - INFLUXDB_URL=http://influxdb:8086
-      - INFLUXDB_USERNAME=${INFLUXDB_USERNAME}
-      - INFLUXDB_PASSWORD=${INFLUXDB_PASSWORD}
+      - INFLUXDB_USERNAME=${INFLUXDB_ADMIN_USER}
+      - INFLUXDB_PASSWORD=${INFLUXDB_ADMIN_PASSWORD}
   grafana:
     image: grafana/grafana:latest
     restart: always
@@ -43,8 +44,8 @@ services:
     image: golift/unifi-poller:${POLLER_TAG}
     environment:
       - UP_INFLUXDB_DB=${INFLUXDB_DB}
-      - UP_INFLUXDB_USER=${INFLUXDB_USER}
-      - UP_INFLUXDB_PASS=${INFLUXDB_PASS}
+      - UP_INFLUXDB_USER=${INFLUXDB_ADMIN_USER}
+      - UP_INFLUXDB_PASS=${INFLUXDB_ADMIN_PASSWORD}
       - UP_INFLUXDB_URL=http://influxdb:8086
       - UP_UNIFI_DEFAULT_USER=${UNIFI_USER}
       - UP_UNIFI_DEFAULT_PASS=${UNIFI_USER}


### PR DESCRIPTION
Turns out auth isn't enabled without `INFLUXDB_HTTP_AUTH_ENABLED`. Oops. This fixes #191.