### PR TITLE
Update docker-compose.yml

### DIFF
--- a/init/docker/docker-compose.yml
+++ b/init/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     image: chronograf:latest
     restart: always
     ports:
-      - '127.0.0.1:8888:8888'
+      - '8888:8888'
     volumes:
       - chronograf-storage:/var/lib/chronograf
     depends_on:


### PR DESCRIPTION
Remove IP address from Chronograf port to make Chronograf accessible from outside of Docker container.