### PR TITLE
Specify InfluxDB version 1.8 in docker-compose.yml

### DIFF
--- a/init/docker/docker-compose.yml
+++ b/init/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   influxdb:
     restart: always
-    image: influxdb:latest
+    image: influxdb:1.8
     ports:
       - '8086:8086'
     volumes:


### PR DESCRIPTION
InfluxDB 1.8 is the latest 1.x version to support the environment variables specified in the `docker-compose.yml`. If set to `latest` the newer 2.x version of InfluxDB is pulled and the user/db is not initialized.